### PR TITLE
Fix: Selecting Environment Id

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "onboardbase-for-vscode",
   "displayName": "Onboardbase",
   "description": "Onboardbase is an app secret infrastructure for dev teams to securely share and work with environment-specific configs synced across every development stage, infrastructure and teammates without compromising security.",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "engines": {
     "vscode": "^1.71.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,7 +76,7 @@ export function activate(context: ExtensionContext) {
 
   commands.registerCommand(
     'onboardbase-extension.upload',
-    async (args: { [key: string]: string | number }) => {
+    async (args: { [key: string]: string }) => {
       await upload(args);
     },
   );

--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -30,10 +30,15 @@ export const getEnvironmentId = async (
   accessToken: string,
 ): Promise<string> => {
   const envs = await fetchProjects(accessToken);
-  const envId = envs.find((e) =>
-    e.environments.list.find((el) => el.title === env),
+  let environmentId: string;
+  envs.find((e) =>
+    e.environments.list.find((el) => {
+      if (el.title === env) {
+        environmentId = el.id;
+      }
+    }),
   );
-  return envId.environments.list[0].id;
+  return environmentId;
 };
 
 export const checkForProjectScope = (): boolean => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -175,7 +175,8 @@ export const fetchRawSecrets = async (
   const environmentId = await getEnvironmentId(environment, accessToken);
   const secrets = await retrieveSecrets(environmentId, accessToken);
 
-  const userCanFetchSecretUnderEnvironment = secrets.list[0].project.member;
+  const userCanFetchSecretUnderEnvironment =
+    secrets.list.length > 0 ? secrets.list[0].project.member : true;
   if (!userCanFetchSecretUnderEnvironment) {
     throw new Error(
       `You don't have enough permission to update/upload/delete secrets under the ${environment} environment.`,


### PR DESCRIPTION
There was a minor bug in how the env id was selected. I searched through the projects and checked the `list` array which contains all the environments for that project; if the title is the same as the environment in question, if yes, return that particular project. Then the environmentId was selected by picking the first item in the `list` array of the project that was returned from the search. That's where the mistake came from. 
Picking the first one in the list will always result in the `development` environment. So, uploads and retrieval will always go to the `development` environment.
I fixed it by just setting the `environmentId` whenever we encounter the environment in question.